### PR TITLE
fixes for autopreqs

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -5,12 +5,8 @@ copyright_holder = Alex J. G. Burzyński <ajgb@cpan.org>
 copyright_year   = 2012
 
 [@Filter]
--bundle=@AJGB
--remove=CompileTests
--remove=PortabilityTests
+-bundle = @AJGB
+-remove = AutoPrereqs
 
 [AutoPrereqs]
-[Test::Compile]
-[Test::Portability]
-
-
+skip = ^My::Singleton::


### PR DESCRIPTION
✗ sudo cpanm MooX::Singleton
--> Working on MooX::Singleton
Fetching http://www.cpan.org/authors/id/A/AJ/AJGB/MooX-Singleton-1.121160.tar.gz ... OK
Configuring MooX-Singleton-1.121160 ... OK
==> Found dependencies: My::Singleton::E, My::Singleton::B, My::Singleton::C, My::Singleton::A, My::Singleton::D
! Finding My::Singleton::E on cpanmetadb failed.
