### PR TITLE
Let people create instances from instances

### DIFF
--- a/lib/MooX/Singleton.pm
+++ b/lib/MooX/Singleton.pm
@@ -38,7 +38,8 @@ arguments.
 =cut
 
 sub instance {
-    my $class = shift;
+    my $invocant = shift;
+    my $class = ref $invocant || $invocant;
 
     no strict 'refs';
     my $instance = \${"$class\::_instance"};

--- a/t/moox-singleton.t
+++ b/t/moox-singleton.t
@@ -1,7 +1,9 @@
 
 use strict;
 use warnings;
-use Test::More tests => 138;
+use Test::More tests => 139;
+
+use Scalar::Util qw(refaddr);
 
 {
     package My::Singleton::A;
@@ -208,6 +210,8 @@ my $aa2 = My::Singleton::A::A2->instance;
 isa_ok($aa2, "My::Singleton::A::A2");
 ok(My::Singleton::A::A2->_has_instance, "instance created");
 is $aa2->attrib, "value", '$aa2->attrib correct';
+my $aa2_again = $aa2->instance;
+is refaddr($aa2_again), refaddr($aa2), 'Creating an instance from an instance creates the same instance';
 
 my $aa22 = My::Singleton::A::A2->instance( attrib => "new value" );
 isa_ok($aa22, "My::Singleton::A::A2");


### PR DESCRIPTION
This is the recently-raised [RT 152313 ticket](https://rt.cpan.org/Public/Bug/Display.html?id=152313). This affects any Moo class with attributes, which therefore use Sub::Quote for their constructor.